### PR TITLE
chore: prepare release v1.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -9,7 +9,8 @@ body:
     attributes:
       value: |
         **Important**
-        Please do **not** disclose sensitive details publicly until we coordinate a fix. For urgent issues, also email `samer.farida@yahoo.com` as documented in `SECURITY.md`.
+        Please do **not** disclose sensitive details publicly until we coordinate a fix.
+        For urgent issues, also email `samer.farida@yahoo.com` as documented in `SECURITY.md`.
   - type: dropdown
     id: severity
     attributes:
@@ -32,7 +33,7 @@ body:
       label: Affected version / environment
       description: Include commit SHA or tag, Docker vs local venv, MCP client, etc.
       placeholder: |
-        Version: v1.0.0
+        Version: v1.3.0
         Environment: Docker
         MCP client: Cursor
     validations:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,7 +76,7 @@ updates:
       - "docker"
     ignore:
       # CRITICAL: Block Python 3.14+ updates
-      # MCP SDK (mcp>=1.21.0) officially supports only Python 3.10-3.13
+      # MCP SDK (mcp>=1.27.0) officially supports only Python 3.10-3.13
       # See: https://github.com/modelcontextprotocol/python-sdk
       # TODO: Remove this ignore when MCP SDK adds official Python 3.14 support
       - dependency-name: "python"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to mcp-ssh-orchestrator will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-26
+
+### Changed
+- **Dependencies**: Updated MCP SDK from 1.26.0 to 1.27.0 (#122, #111)
+- **Dependencies**: Updated transitive `python-multipart` pin in the hashed lockfile (#122, #102)
+- **Docker**: Updated Python 3.13-slim base image digest for the container image
+  - Updated from `51e1a0a` to `2ba73a4` (#122, #112) and refreshed again to `d2462a6` (#112)
+  - Additional digest refreshes landed on `main` after v1.2.0: `baf6668` → `1f3781f` → `51e1a0a` (#97, #98)
+- **CI/CD**: Grouped GitHub Actions updates for release + security scanning (#121)
+  - `docker/login-action` 3.7.0 (#121, #103)
+  - `aquasecurity/trivy-action` 0.34.1 (#121, #107)
+  - `actions/attest-build-provenance` 4.1.0 (#121, #108)
+  - `actions/attest-sbom` 4.0.0 (#121, #109)
+  - `actions/upload-artifact` 7.0.0 (Scorecards workflow) (#121, #110)
+  - `actions/setup-node` 6.2.0 (#100)
+- **Development Dependencies**: Raised dev/test tool floors (#123, #99, and related Dependabot PRs)
+  - Black 26.x, pytest 9.x, pytest-asyncio 1.3.x, pytest-cov 7.1.x, pytest-mock 3.15.x
+  - mypy 1.20.x, pip-tools 7.5.x, setuptools 82.x (build-system requires)
+- **Dependencies**: Updated MCP SDK from 1.25.0 to 1.26.0 (#101)
+- **Developer Experience**: Added `scripts/ci-local.sh` to run CI-parity checks locally before pushing (#121)
+
 ## [1.2.0] - 2025-12-27
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7
-# NOTE: Python 3.13 is pinned here because MCP SDK (mcp>=1.21.0) officially
+# NOTE: Python 3.13 is pinned here because MCP SDK (mcp>=1.27.0) officially
 # supports only Python 3.10-3.13. Python 3.14 is not yet officially supported.
 # DO NOT update to Python 3.14 until MCP SDK adds official support.
 # See: https://github.com/modelcontextprotocol/python-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # DO NOT update to Python 3.14 until MCP SDK adds official support.
 # See: https://github.com/modelcontextprotocol/python-sdk
 # To prevent Dependabot from bumping this, see .github/dependabot.yml
-FROM python:3.13.13-slim@sha256:2ba73a4dc380f21137fc75296abfa2add90b51fd10b609ce530b40cc097269b1 AS base
+FROM python:3.13.13-slim@sha256:d2462a6bed37b4fc6cabecf5a2132ae70df772fe03c7393c4d98a0c2fb48aa2e AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ MCP SSH Orchestrator directly addresses documented vulnerabilities in the MCP ec
 
 ```bash
 gpg --receive-keys 4FC5342A979BD358
-gpg --verify mcp-ssh-orchestrator-v1.0.0.tar.gz.asc mcp-ssh-orchestrator-v1.0.0.tar.gz
+gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
 ```
 
 **Cosign-signed container images**: The images under `ghcr.io/samerfarida/mcp-ssh-orchestrator` are signed via Sigstore keyless signing in the release workflow. Verify the signature (and optional attestations) before deploying:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </div>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-A020F0)](LICENSE)
-[![MCP](https://img.shields.io/badge/MCP-v1.21.1-7393B3)](https://modelcontextprotocol.io)
+[![MCP](https://img.shields.io/badge/MCP-v1.27.0-7393B3)](https://pypi.org/project/mcp/1.27.0/)
 [![Python](https://img.shields.io/badge/Python-v3.13+-blue.svg)](https://python.org)
 [![Docker](https://img.shields.io/badge/Docker-Ready-success)](https://github.com/samerfarida/mcp-ssh-orchestrator)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/samerfarida/mcp-ssh-orchestrator/badge)](https://scorecard.dev/viewer/?uri=github.com/samerfarida/mcp-ssh-orchestrator)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -136,7 +136,7 @@ Per the project instructions:
 7. Log to stderr
 8. Graceful error handling only
 
-**Note on Prompts:** Prompts are implemented following the [MCP Prompts specification](https://pypi.org/project/mcp/1.21.0/#prompts). Use `@mcp.prompt()` decorators as documented in the MCP SDK. The server includes 6 prompts: `ssh_orchestrator_usage`, `ssh_policy_denied_guidance`, `ssh_network_denied_guidance`, `ssh_missing_host_guidance`, `ssh_missing_credentials_guidance`, and `ssh_config_change_workflow`.
+**Note on Prompts:** Prompts are implemented following the [MCP Prompts specification](https://pypi.org/project/mcp/1.27.0/#prompts). Use `@mcp.prompt()` decorators as documented in the MCP SDK. The server includes 6 prompts: `ssh_orchestrator_usage`, `ssh_policy_denied_guidance`, `ssh_network_denied_guidance`, `ssh_missing_host_guidance`, `ssh_missing_credentials_guidance`, and `ssh_config_change_workflow`.
 
 ### Example MCP Tool
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -517,7 +517,7 @@ chmod 0400 ~/mcp-ssh/secrets/key_passphrase
 
      ```bash
      gpg --receive-keys 4FC5342A979BD358
-     gpg --verify mcp-ssh-orchestrator-v1.0.0.tar.gz.asc mcp-ssh-orchestrator-v1.0.0.tar.gz
+     gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
      ```
 
 1. **Container Images (GHCR)**

--- a/docs/wiki/05-Security-Model.md
+++ b/docs/wiki/05-Security-Model.md
@@ -515,7 +515,7 @@ overrides:
 
   ```bash
   gpg --receive-keys 4FC5342A979BD358
-  gpg --verify mcp-ssh-orchestrator-v1.0.0.tar.gz.asc mcp-ssh-orchestrator-v1.0.0.tar.gz
+  gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
   ```
 
 - **Cosign-signed container images**: The GitHub Actions release workflow signs `ghcr.io/samerfarida/mcp-ssh-orchestrator` with Sigstore keyless certificates (`release.yml`). Validate the signature and provenance in CI/CD before promotion:

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "mcp-ssh-orchestrator",
   "displayName": "MCP SSH Orchestrator",
   "description": "A Model Context Protocol (MCP) server for orchestrating SSH operations across multiple servers with security policies and parallel execution capabilities.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "samerfarida",
   "license": "Apache-2.0",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-ssh-orchestrator"
-version = "1.2.0"
+version = "1.3.0"
 description = "A secure SSH fleet orchestrator for MCP (STDIO transport)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/servers/io.github.samerfarida/mcp-ssh-orchestrator/server.json
+++ b/servers/io.github.samerfarida/mcp-ssh-orchestrator/server.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-ssh-orchestrator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A secure SSH fleet orchestrator exposing list/plan/run tools with policy enforcement over STDIO.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/samerfarida/mcp-ssh-orchestrator",


### PR DESCRIPTION
## Summary
- Bump version metadata to **1.3.0** (`pyproject.toml`, `metadata.json`, MCP server manifest).
- Add `CHANGELOG.md` section for **1.3.0** so `release.yml` can populate the GitHub Release body.
- Refresh the Docker base image digest to match Dependabot PR **#112** (`python:3.13.13-slim@sha256:d2462a6…`).

## Release sequencing
1. Merge this PR.
2. `git checkout main && git pull --ff-only`
3. `git tag -a v1.3.0 -m "Release v1.3.0" && git push origin v1.3.0`
4. Watch `Release` workflow + verify GHCR + GitHub Release assets.

## Housekeeping (upstream)
After merge/tag, close stale Dependabot PRs that were superseded by grouped PRs **#121–#123** (they stay open unless explicitly closed):
- **#103 #107 #108 #109 #110 #102 #111** (and any other still-open duplicates)

`#112` should be closable as superseded by this PR once the digest matches.

## Test plan
- [x] `PATH="$(pwd)/.venv/bin:$PATH" ./scripts/ci-local.sh`
- [x] `python -m build --sdist --wheel` (local dry-run)
- [x] `docker buildx build --platform linux/amd64,linux/arm64` (local dry-run)

Made with [Cursor](https://cursor.com)