### PR TITLE
chore: prepare release v1.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/security_vulnerability.yml
+++ b/.github/ISSUE_TEMPLATE/security_vulnerability.yml
@@ -33,7 +33,7 @@ body:
       label: Affected version / environment
       description: Include commit SHA or tag, Docker vs local venv, MCP client, etc.
       placeholder: |
-        Version: v1.3.0
+        Version: v1.3.2
         Environment: Docker
         MCP client: Cursor
     validations:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-07-02
+
 ### Security
 - **cryptography**: 46.0.7 → 49.0.0 — major bump via transitive `paramiko` / `pyjwt[crypto]` chain; `requirements.in` cap updated to `<50.0.0` (#145).
 - **PyJWT**: 2.12.1 → 2.13.0 — patch bump; security floor in `requirements.in` updated (#140).

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ MCP SSH Orchestrator directly addresses documented vulnerabilities in the MCP ec
 
 ```bash
 gpg --receive-keys 4FC5342A979BD358
-gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
+gpg --verify mcp-ssh-orchestrator-v1.3.2.tar.gz.asc mcp-ssh-orchestrator-v1.3.2.tar.gz
 ```
 
 **Cosign-signed container images**: The images under `ghcr.io/samerfarida/mcp-ssh-orchestrator` are signed via Sigstore keyless signing in the release workflow. Verify the signature (and optional attestations) before deploying:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -517,7 +517,7 @@ chmod 0400 ~/mcp-ssh/secrets/key_passphrase
 
      ```bash
      gpg --receive-keys 4FC5342A979BD358
-     gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
+     gpg --verify mcp-ssh-orchestrator-v1.3.2.tar.gz.asc mcp-ssh-orchestrator-v1.3.2.tar.gz
      ```
 
 1. **Container Images (GHCR)**

--- a/docs/wiki/05-Security-Model.md
+++ b/docs/wiki/05-Security-Model.md
@@ -515,7 +515,7 @@ overrides:
 
   ```bash
   gpg --receive-keys 4FC5342A979BD358
-  gpg --verify mcp-ssh-orchestrator-v1.3.0.tar.gz.asc mcp-ssh-orchestrator-v1.3.0.tar.gz
+  gpg --verify mcp-ssh-orchestrator-v1.3.2.tar.gz.asc mcp-ssh-orchestrator-v1.3.2.tar.gz
   ```
 
 - **Cosign-signed container images**: The GitHub Actions release workflow signs `ghcr.io/samerfarida/mcp-ssh-orchestrator` with Sigstore keyless certificates (`release.yml`). Validate the signature and provenance in CI/CD before promotion:

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "mcp-ssh-orchestrator",
   "displayName": "MCP SSH Orchestrator",
   "description": "A Model Context Protocol (MCP) server for orchestrating SSH operations across multiple servers with security policies and parallel execution capabilities.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "samerfarida",
   "license": "Apache-2.0",
   "repository": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-ssh-orchestrator"
-version = "1.3.1"
+version = "1.3.2"
 description = "A secure SSH fleet orchestrator for MCP (STDIO transport)."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/servers/io.github.samerfarida/mcp-ssh-orchestrator/server.json
+++ b/servers/io.github.samerfarida/mcp-ssh-orchestrator/server.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-ssh-orchestrator",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "A secure SSH fleet orchestrator exposing list/plan/run tools with policy enforcement over STDIO.",
   "license": "Apache-2.0",
   "homepage": "https://github.com/samerfarida/mcp-ssh-orchestrator",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Patch release that closes the dependency and CI updates deferred from v1.3.1.

### What's in v1.3.2

**Security**
- cryptography 46.0.7 → 49.0.0 (#145)
- PyJWT 2.12.1 → 2.13.0 (#140)
- python-multipart 0.0.26 → 0.0.32 (#143)

**Changed**
- MCP SDK 1.27.0 → 1.27.2 (#141)
- paramiko cap expanded to `<6.0.0` (#139)
- Docker Python 3.13.13 → 3.13.14 (#144)
- mypy dev constraint `<3.0.0` (#134)
- CI action bumps deferred from v1.3.1 (#125–#130, #128)

### Release prep

- Bump version to `1.3.2` in `pyproject.toml`, `metadata.json`, and `server.json`
- Finalize CHANGELOG (`[1.3.2] - 2026-07-02`)
- Refresh GPG verification examples to v1.3.2

Dependency-only change; no source-code edits.

### CI status

All checks green (Lint, Docker Build, Python 3.11/3.12/3.13 tests, Ruff, Black, Type Checking, CodeQL, Markdown Linting).

**After merge:** tag `v1.3.2` on `main` to trigger the automated release workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2289-c57b-7d2c-9fde-6954fcab2b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2289-c57b-7d2c-9fde-6954fcab2b49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

